### PR TITLE
WECO-1125: Support android-packageName in config

### DIFF
--- a/hooks/androidGradleConfig.js
+++ b/hooks/androidGradleConfig.js
@@ -137,9 +137,16 @@ module.exports = function (context) {
   );
   const config = new ConfigParser(configPath);
 
-  const androidAppNameComponents = config.packageName().split(".");
-  const androidAppName =
-    androidAppNameComponents[androidAppNameComponents.length - 1];
+  // packagename validated by Cordova
+  // https://github.com/apache/cordova-android/blob/5eddc460e49a5b8ce2bcc43d0a22fe4511842085/lib/create.js#L216
+  const androidPackageName =
+    config.android_packageName() || config.packageName();
+
+  // derive project name
+  // https://github.com/apache/cordova-android/blob/5eddc460e49a5b8ce2bcc43d0a22fe4511842085/lib/config/CordovaGradleConfigParser.js#L57
+  const androidAppName = androidPackageName.substring(
+    androidPackageName.lastIndexOf(".") + 1
+  );
 
   const gradleExtrasPath = path.join(
     projectRoot,


### PR DESCRIPTION
[Ticket](https://fullstory.atlassian.net/browse/WECO-1125)

### Context explanation

To support auto configuration of android gradle files, our cordova plugin has a "template" gradle file [here](https://github.com/fullstorydev/fullstory-cordova-plugin/blob/0f313a703848e3ba76cdd5414401dbf234130bdf/src/android/plugin.gradle#L1), which we rewrite during the build process based on user configurations, and we connect this file to the main project gradle file. 

Before the build process starts, cordova will copy over this "template" gradle file into the `platform/android/fullstory-cordova-plugin` directory, and name it `${appname}-plugin.gradle`. During build, our plugin will try to find this `${appname}-plugin.gradle` file by deriving the `appname` from the widget `id` value. 

### Issue
However, if the user has configured the `android-packageName`, this overrides the `id` value, and we will not be able to find the file for rewrite, since we still think `id` is the `appname`. 

This work copies cordova's internal code on how to derive `appname`, and will now support the `android-packageName` configuration.