### PR TITLE
use cimg/node instead of circleci/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 executors:
   browser-executor:
     docker:
-      - image: circleci/node:16-browsers
+      - image: cimg/node:16.20.2-browsers
     working_directory: ~/repo
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs


### PR DESCRIPTION
circleci/node is super deprecated, use the supported images instead (cimg/node)